### PR TITLE
Non-updating rank table fix and tiebreaker logic

### DIFF
--- a/rankendpoint.py
+++ b/rankendpoint.py
@@ -77,10 +77,12 @@ def fetch_my_ranks(pcuid, epid, date):
             RaceResults.PlayerID,
             Players.FirstName,
             Players.LastName,
-            MAX(RaceResults.Score) AS MaxScore
+            RaceResults.Score
         FROM RaceResults
         INNER JOIN Players ON RaceResults.PlayerID=Players.PlayerID
-        WHERE RaceResults.PlayerID=? AND EPID=? AND DATETIME(Timestamp, 'unixepoch') > DATETIME('now', ?);
+        WHERE RaceResults.PlayerID=? AND EPID=? AND DATETIME(Timestamp, 'unixepoch') > DATETIME('now', ?)
+        ORDER BY RaceResults.Score DESC
+        LIMIT 1;
         """
 
     args = (pcuid, epid, date)


### PR DESCRIPTION
`fetch_ranks`: Doing `GROUP BY` in the outer scope was messing things up. Using `ROW_NUMBER` and `PARTITION BY` to achieve the intended result gives us more flexibility (to e.g. add a tiebreaker for capped scores), while having comparable speed to the old version.